### PR TITLE
fix: switch message formatting from Markdown to HTML

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,17 +121,18 @@ async def forward_message_with_media(client, original_message, translated_text, 
             await client.send_file(
                 target_channel,
                 original_message.media,
-                caption=formatted_text
+                caption=formatted_text,
+                parse_mode='html'
             )
         except Exception as e:
             logger.warning(f"Error forwarding media: {e}")
             # Fallback: send text only if media forwarding fails
-            await client.send_message(target_channel, formatted_text)
+            await client.send_message(target_channel, formatted_text, parse_mode='html')
     else:
         if len(formatted_text) > 4096:
             logger.warning(f"Message too long: {formatted_text}, skipping")
         else:
-            await client.send_message(target_channel, formatted_text)
+            await client.send_message(target_channel, formatted_text, parse_mode='html')
 
 
 async def main():

--- a/system_prompt_editorial_guidelines.txt
+++ b/system_prompt_editorial_guidelines.txt
@@ -1,17 +1,25 @@
 1. Translation
 News items may be in different languages. Always translate them into fluent, clear English. 
 
-2. Link Preservation
+2. Link and Formatting Preservation
 
-**CRITICAL**: If the original message includes any **links** in markdown format (e.g., [text](URL) or [**bold text**](URL)), you MUST preserve them exactly in the translated version. 
+**CRITICAL**: Use HTML formatting for all text styling. Do NOT use Markdown syntax.
+
+Formatting rules:
+- Bold text: <b>text</b>
+- Links: <a href="URL">text</a>
+- Bold links: <a href="URL"><b>text</b></a>
+- Italic: <i>text</i>
+
+If the original message includes any links, you MUST preserve them in the translated version using HTML format.
 
 Examples:
 - Original: "[Посібник з безпеки iOS](https://example.com)"
-- Translated: "[iOS Security Guide](https://example.com)" 
+- Translated: <a href="https://example.com">iOS Security Guide</a>
 - Original: "[**Нові функції Swift**](https://swift.org/news)"
-- Translated: "[**New Swift Features**](https://swift.org/news)" 
+- Translated: <a href="https://swift.org/news"><b>New Swift Features</b></a>
 
-Never remove links, URLs, or markdown formatting syntax. Always translate only the link text while keeping the URL and markdown brackets unchanged.
+Never remove links or URLs. Always translate only the link text while keeping the URL unchanged.
 
 3. Structural Preservation
 
@@ -22,7 +30,8 @@ Maintain the original structure of the message:
 - Do not merge separate sentences/paragraphs into one
 - Do not reorder elements
 - Do not add new lines unless needed by translation
-- Keep list formatting, bullet points, emojis, heading levels, and spacing intact
+- Keep list formatting, bullet points, emojis, and spacing intact
+- Do NOT use Markdown syntax (**, [], etc.) — use only HTML tags for formatting
 
 4. Verification
 Disregard obviously fake, unverifiable news, clickbait, or low-quality gossip.


### PR DESCRIPTION
## Summary

Fix literal `**text**` asterisks appearing in bot messages instead of rendered bold formatting. Switch from Markdown to HTML parse mode for Telegram message sending.

## Changes

- Add `parse_mode='html'` to all `send_message()` and `send_file()` calls in `forward_message_with_media()`
- Update editorial guidelines to instruct the AI to output HTML formatting (`<b>`, `<a href>`) instead of Markdown (`**`, `[]()`)
- Enable bold links via `<a href="url"><b>text</b></a>`, which Telegram's HTML mode supports but Markdown mode does not

## Impact & Risk

- Messages will now render bold text, links, and bold links correctly
- Existing messages in the database won't be reprocessed, so only new messages are affected
- If the AI occasionally outputs Markdown syntax despite the updated prompt, those characters will appear literally — but this is the same behavior as before, and the prompt is explicit about using HTML

## Notes

Telegram's Markdown parser does not support nested formatting (e.g., bold inside a link). HTML mode handles this natively with `<a><b>text</b></a>`.